### PR TITLE
Update cocotb Environment Scripts to Avoid Polluting Home Directory

### DIFF
--- a/asic/verif/run.sh
+++ b/asic/verif/run.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # Activate virtual environment
-source "$HOME/cocotb-env/bin/activate"
+if [ -d "$HOME/.app-env" ]; then
+  APP_PREFIX="$HOME/.app-env"
+else
+  APP_PREFIX="$HOME"
+fi
+source "$APP_PREFIX/cocotb-env/bin/activate"
 
 # Prepend cocotb-config from the venv to the PATH
 if [ -e "$VIRTUAL_ENV/bin/cocotb-config" ]; then

--- a/create_cocotb_venv.sh
+++ b/create_cocotb_venv.sh
@@ -4,39 +4,41 @@
 PYTHON_VERSION=3.11.8
 OPENSSL_VERSION=1.1.1w
 LIBFFI_VERSION=3.4.4
-INSTALL_PREFIX="$HOME/local"
-VENV_PATH="$HOME/cocotb-env"
+APP_PREFIX=$HOME/.app-env
+INSTALL_PREFIX="$HOME/.app-env/local"
+SRC_DIR="$HOME/.app-env/src"
+VENV_PATH="$HOME/.app-env/cocotb-env"
 
 # === DIRECTORIES ===
-mkdir -p ~/build && cd ~/build
+mkdir -p $SRC_DIR && cd $SRC_DIR
 
 # === Build OpenSSL ===
 wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 rm -rf openssl-$OPENSSL_VERSION && tar xzf openssl-$OPENSSL_VERSION.tar.gz && cd openssl-$OPENSSL_VERSION
-./config --prefix=$HOME/openssl --openssldir=$HOME/openssl no-shared
+./config --prefix=$APP_PREFIX/openssl --openssldir=$APP_PREFIX/openssl no-shared
 make -j$(nproc)
 make install
 
 # === Build libffi ===
-cd ~/build
+cd $SRC_DIR
 wget https://github.com/libffi/libffi/releases/download/v$LIBFFI_VERSION/libffi-$LIBFFI_VERSION.tar.gz
 rm -rf libffi-$LIBFFI_VERSION && tar xzf libffi-$LIBFFI_VERSION.tar.gz && cd libffi-$LIBFFI_VERSION
-./configure --prefix=$HOME/libffi --disable-shared --enable-static CFLAGS="-fPIC"
+./configure --prefix=$APP_PREFIX/libffi --disable-shared --enable-static CFLAGS="-fPIC"
 make -j$(nproc)
 make install
 
 # === Build Python ===
-cd ~/build
+cd $SRC_DIR
 wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
 rm -rf Python-$PYTHON_VERSION && tar xzf Python-$PYTHON_VERSION.tgz && cd Python-$PYTHON_VERSION
 
-PKG_CONFIG_PATH=$HOME/libffi/lib64/pkgconfig \
+PKG_CONFIG_PATH=$APP_PREFIX/libffi/lib64/pkgconfig \
 ./configure --prefix=$INSTALL_PREFIX \
-            --with-openssl=$HOME/openssl \
+            --with-openssl=$APP_PREFIX/openssl \
             --with-system-ffi \
             --enable-shared \
-            CPPFLAGS="-I$HOME/libffi/include -fPIC" \
-            LDFLAGS="-L$HOME/libffi/lib64 -Wl,-rpath=$HOME/local/lib"
+            CPPFLAGS="-I$APP_PREFIX/libffi/include -fPIC" \
+            LDFLAGS="-L$APP_PREFIX/libffi/lib64 -Wl,-rpath=$APP_PREFIX/local/lib"
 make -j$(nproc)
 make install
 

--- a/verif/run_venv.sh
+++ b/verif/run_venv.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # Activate virtual environment
-source "$HOME/cocotb-env/bin/activate"
+if [ -d "$HOME/.app-env" ]; then
+  APP_PREFIX="$HOME/.app-env"
+else
+  APP_PREFIX="$HOME"
+fi
+source "$APP_PREFIX/cocotb-env/bin/activate"
 
 # Prepend cocotb-config from the venv to the PATH
 if [ -e "$VIRTUAL_ENV/bin/cocotb-config" ]; then


### PR DESCRIPTION
I have updated the create-cocotb-env script to put everything in `~/.app-env`. I have also updated the run scripts, using the assignment
```bash
if [ -d "$HOME/.app-env" ]; then
  APP_PREFIX="$HOME/.app-env"
else
  APP_PREFIX="$HOME"
fi
source "$APP_PREFIX/cocotb-env/bin/activate"
```
to maintain compatibility with environments created before this change, so that you will not have to re-create your virtual environment.