### PR TITLE
Fix issue with CLK_NBITS parameter in clk_cnter

### DIFF
--- a/asic/verilog/analog_if/clk_cnter.v
+++ b/asic/verilog/analog_if/clk_cnter.v
@@ -7,7 +7,7 @@ module clk_cnter #(parameter CLK_NBITS=8) (
 				   input wire 		       rstb
 				   );
 
-   reg [7:0] clock_cnt;
+   reg [CLK_NBITS-1:0] clock_cnt;
    assign clk_cnt_o = clock_cnt;
 
    always @(posedge clk, negedge rstb ) begin


### PR DESCRIPTION
I noticed that the internal register storing the clock count did not respect the CLK_NBITS parameter and instead was hardcoded to 7. Unless this behaviour is intentional, this seems like it would be an issue.